### PR TITLE
Fix link to the website docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,6 @@ Before we can merge your changes, you must agree to the [Uber Contributor Licens
 
 In addition to making pull requests and Github issues on the @uber/h3 repository, there are other ways you can contribute. Here are some suggestions:
 
-* Writing and updating the [documentation website](./docs/).
+* Writing and updating the [documentation website](./website/docs/).
 * Writing [bindings](./dev-docs/creating_bindings.md) for your preferred language.
 * Writing components so that your preferred GIS, mapping, or visualization system can display H3 indexes.


### PR DESCRIPTION
Fix the link to website docs from `./docs` to `./website/docs`.

Fixes #778